### PR TITLE
 use decodeURIComponent() instead of unescape() to support multibyte data

### DIFF
--- a/src/com/pnwrain/flashsocket/FlashSocket.as
+++ b/src/com/pnwrain/flashsocket/FlashSocket.as
@@ -193,7 +193,7 @@ package com.pnwrain.flashsocket
 			
 			if ( data.type == "message" ){
 				this._setTimeout();
-				var msg:String = unescape(data.data);
+				var msg:String = decodeURIComponent(data.data);
 				if (msg){
 					this._onMessage(msg);
 				}


### PR DESCRIPTION
because web-socket-js use encodeURIComponent(), so change Flashsocket.as use decodeURIComponent() instead of unescape() to support multibyte data (like chinese.).
